### PR TITLE
Adding a feature to allow players to see their role mid-game.

### DIFF
--- a/api/templates/game.html.j2
+++ b/api/templates/game.html.j2
@@ -44,6 +44,7 @@
         <button onclick="window.location.href='/join/{{ game_id }}'"
             class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--colored" id="join_game"
             hidden>Join Game</button>
+        <button id="show_role_button" onclick="showMyRole()">Show My Role</button>
 
         <div id="question_input" hidden>
             <input id="question" autocomplete="off" class="question-box" type="search" list="questions"


### PR DESCRIPTION
This feature introduces a 'Show My Role' button, visible during active game phases (night, day, voting).

- Clicking the button triggers a request to the server.
- The server responds with the player's role information (name, description, image), which is then displayed in a dialog box.
- Role information is only sent to the requesting player.
- The button's visibility is controlled by game state (hidden during setup, finished, and for spectators).
- Includes client-side JavaScript and server-side SocketIO handlers for this functionality.